### PR TITLE
Serializing/Desierializing Events by their name

### DIFF
--- a/Tacta.EventStore.Test/DependencyInjection/EventStoreConfigurationTest.cs
+++ b/Tacta.EventStore.Test/DependencyInjection/EventStoreConfigurationTest.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Tacta.EventStore.DependencyInjection;
+using Tacta.EventStore.Domain;
+using Xunit;
+
+namespace Tacta.EventStore.Test.DependencyInjection
+{
+    #region DuplicateEventForTesting
+    public sealed class BacklogItemCreated : DomainEvent
+    {
+        public BacklogItemCreated(string aggregateId) : base(aggregateId) { }
+        public BacklogItemCreated(Guid id, string aggregateId, DateTime createdAt) : base(id, aggregateId, createdAt) { }
+    }
+    #endregion
+    
+    public class EventStoreConfigurationTest
+    {
+        [Fact]
+        public void GivenTwoEventsWithTheSameName_WhenRegisteringEventStore_ShouldThrowException()
+        {
+            // Given
+            var services = new ServiceCollection();
+            var assemblies = new Assembly[]
+            {
+                typeof(BacklogItemCreated).Assembly,
+            };
+
+            // When + Then
+            var exception = Assert.Throws<ArgumentException>(() => services.AddEventStoreRepository(assemblies));
+            Assert.Contains(typeof(Domain.DomainEvents.BacklogItemCreated).FullName!, exception.Message);
+            Assert.Contains(typeof(Domain.DomainEvents.BacklogItemCreated).Assembly.FullName!, exception.Message);
+            Assert.Contains(typeof(BacklogItemCreated).FullName!, exception.Message);
+            Assert.Contains(typeof(BacklogItemCreated).Assembly.FullName!, exception.Message);
+        }
+    }
+}

--- a/Tacta.EventStore.Test/Projector/ProjectionProcessorTest.cs
+++ b/Tacta.EventStore.Test/Projector/ProjectionProcessorTest.cs
@@ -3,16 +3,14 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Moq;
+using Tacta.EventStore.DependencyInjection;
 using Tacta.EventStore.Domain;
 using Tacta.EventStore.Projector;
 using Tacta.EventStore.Repository;
 using Tacta.EventStore.Repository.Models;
-using Tacta.EventStore.Test.Projector.DomainEvents;
-using Tacta.EventStore.Test.Projector.Projections;
 using Tacta.EventStore.Test.Repository;
 using Tacta.EventStore.Test.Repository.DomainEvents;
 using Xunit;
@@ -33,7 +31,13 @@ namespace Tacta.EventStore.Test.Projector
         public ProjectionProcessorTest()
         {
             _projectionMock = new Mock<IProjection>();
-            _eventStoreRepository = new EventStoreRepository(ConnectionFactory);
+            var domainEvents = new Dictionary<string, Type>
+            {
+                {nameof(FooRegistered), typeof(FooRegistered)},
+                {nameof(BooCreated), typeof(BooCreated)},
+                {nameof(BooActivated), typeof(BooActivated)}
+            };
+            _eventStoreRepository = new EventStoreRepository(ConnectionFactory, new EventNameToTypeConverter(domainEvents));
         }
         
         [Fact]

--- a/Tacta.EventStore.Test/Repository/EventStoreRepositoryTest.cs
+++ b/Tacta.EventStore.Test/Repository/EventStoreRepositoryTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Tacta.EventStore.DependencyInjection;
 using Tacta.EventStore.Domain;
 using Tacta.EventStore.Repository;
 using Tacta.EventStore.Repository.Exceptions;
@@ -20,7 +21,15 @@ namespace Tacta.EventStore.Test.Repository
 
         public EventStoreRepositoryTest()
         {
-            _eventStoreRepository = new EventStoreRepository(ConnectionFactory);
+            var eventNameConverter = new EventNameToTypeConverter(new Dictionary<string, Type>
+            {
+                {nameof(BacklogItemCreated), typeof(BacklogItemCreated)},
+                {nameof(SubTaskAdded), typeof(SubTaskAdded)},
+                {nameof(FooRegistered), typeof(FooRegistered)},
+                {nameof(BooCreated), typeof(BooCreated)},
+                {nameof(BooActivated), typeof(BooActivated)}
+            });
+            _eventStoreRepository = new EventStoreRepository(ConnectionFactory, eventNameConverter);
         }
 
 

--- a/Tacta.EventStore.Test/Repository/ExceptionHandlingTest.cs
+++ b/Tacta.EventStore.Test/Repository/ExceptionHandlingTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Tacta.EventStore.DependencyInjection;
 using Tacta.EventStore.Domain;
 using Tacta.EventStore.Repository;
 using Tacta.EventStore.Repository.Exceptions;
@@ -18,7 +19,7 @@ namespace Tacta.EventStore.Test.Repository
 
         public ExceptionHandlingTest()
         {
-            _eventStoreRepository = new EventStoreRepository(null);
+            _eventStoreRepository = new EventStoreRepository(null, (IEventNameToTypeConverter)null);
         }
 
         [Fact]

--- a/Tacta.EventStore/DependencyInjection/EventNameToTypeConverter.cs
+++ b/Tacta.EventStore/DependencyInjection/EventNameToTypeConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tacta.EventStore.DependencyInjection
+{
+    public class EventNameToTypeConverter : IEventNameToTypeConverter
+    {
+        private readonly IDictionary<string, Type> _eventTypeLookup;
+
+        public EventNameToTypeConverter(IDictionary<string, Type> eventTypeLookup)
+        {
+            _eventTypeLookup = eventTypeLookup;
+        }
+        
+        public Type GetType(string eventName)
+        {
+            if (string.IsNullOrEmpty(eventName))
+            {
+                throw new ArgumentException($"Event Name cannot be empty or NULL!");
+            }
+
+            if (_eventTypeLookup.ContainsKey(eventName) == false)
+            {
+                throw new ArgumentException($"No Event registered for name: '{eventName}'");
+            }
+            
+            var type = _eventTypeLookup[eventName];
+
+            return type;
+        }
+    }
+}

--- a/Tacta.EventStore/DependencyInjection/EventStoreConfiguration.cs
+++ b/Tacta.EventStore/DependencyInjection/EventStoreConfiguration.cs
@@ -1,0 +1,62 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Tacta.EventStore.Domain;
+using Tacta.EventStore.Repository;
+
+namespace Tacta.EventStore.DependencyInjection
+{
+    public static class EventStoreConfiguration
+    {
+        public static IServiceCollection AddEventStoreRepository(this IServiceCollection services, Assembly[] assemblies)
+        {
+            GuardAgainstEventsWithSameName(assemblies);
+            
+            var domainEvents = assemblies
+                .SelectMany(assembly => assembly.GetTypes())
+                .Where(t => typeof(IDomainEvent).IsAssignableFrom(t))
+                .ToDictionary(t => t.Name);
+
+            AddEventStoreRepository(services, domainEvents);
+
+            return services;
+        }
+        
+        public static IServiceCollection AddEventStoreRepository(this IServiceCollection services, IDictionary<string, Type> domainEvents)
+        {
+            services.AddTransient<IEventStoreRepository, EventStoreRepository>();
+            services.AddSingleton<IEventNameToTypeConverter>(new EventNameToTypeConverter(domainEvents));
+
+            return services;
+        }
+
+        private static void GuardAgainstEventsWithSameName(Assembly[] assemblies)
+        {
+            var domainEvents = assemblies
+                .SelectMany(assembly => assembly.GetTypes())
+                .Where(t => typeof(IDomainEvent).IsAssignableFrom(t))
+                .Select(t => (Name: t.Name, Description: t.AssemblyQualifiedName))
+                .ToList();
+                
+            var duplicates = domainEvents
+                .GroupBy(tuple => tuple.Name)
+                .Where(g => g.Count() > 1)
+                .ToList();
+
+            if (duplicates.Any())
+            {
+                var formattedDuplicates = new StringBuilder();
+                var duplicateDomainEvents = duplicates.SelectMany(d => domainEvents.Where(de => de.Name == d.Key));
+                foreach (var duplicateDomainEvent in duplicateDomainEvents)
+                    formattedDuplicates.AppendLine(duplicateDomainEvent.Description);
+                    
+                throw new ArgumentException("Every event has to have a unique name! Following events collide:" +
+                                            $"{Environment.NewLine}{formattedDuplicates}");
+            }
+        }
+    }
+}

--- a/Tacta.EventStore/DependencyInjection/IEventNameToTypeConverter.cs
+++ b/Tacta.EventStore/DependencyInjection/IEventNameToTypeConverter.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Tacta.EventStore.DependencyInjection
+{
+    public interface IEventNameToTypeConverter
+    {
+        Type GetType(string eventName);
+    }
+}

--- a/Tacta.EventStore/Repository/StoredEvent.cs
+++ b/Tacta.EventStore/Repository/StoredEvent.cs
@@ -19,29 +19,29 @@ namespace Tacta.EventStore.Repository
                     VALUES (@Id, @Name, @AggregateId, @Aggregate, @Version, @CreatedAt, @Payload);";
 
         public static string SelectQuery =
-            @"SELECT [Id], [AggregateId], [Version], [CreatedAt], [Payload], [Sequence] 
+            @"SELECT [Id], [Name], [AggregateId], [Version], [CreatedAt], [Payload], [Sequence] 
                 FROM [dbo].[EventStore] WHERE [AggregateId] = @AggregateId";
 
         public static string SelectChunkedWithoutLimitQuery =
-            @"SELECT [Id], [AggregateId], [Version], [CreatedAt], [Payload], [Sequence] 
+            @"SELECT [Id], [Name], [AggregateId], [Version], [CreatedAt], [Payload], [Sequence] 
                 FROM [dbo].[EventStore] 
                 WHERE [Sequence] > @Sequence
                 ORDER BY [Sequence]";
 
         public static string SelectChunkedWithLimitQuery =
-            @"SELECT TOP (@Take) [Id], [AggregateId], [Version], [CreatedAt], [Payload], [Sequence] 
+            @"SELECT TOP (@Take) [Id], [Name], [AggregateId], [Version], [CreatedAt], [Payload], [Sequence] 
                 FROM [dbo].[EventStore] 
                 WHERE [Sequence] > @Sequence
                 ORDER BY [Sequence]";
 
         public static string SelectUntilEventQuery =
-            @"SELECT [Id], [AggregateId], [Version], [CreatedAt], [Payload], [Sequence] 
+            @"SELECT [Id], [Name], [AggregateId], [Version], [CreatedAt], [Payload], [Sequence] 
                 FROM [dbo].[EventStore] 
                 WHERE [AggregateId] = @AggregateId AND [Sequence] <= (SELECT TOP 1 [Sequence] FROM [dbo].[EventStore] WHERE [Id] = @EventId)
                 ORDER BY [Sequence]";
 
         public static string SelectUntilSequenceQuery =
-            @"SELECT [Id], [AggregateId], [Version], [CreatedAt], [Payload], [Sequence] 
+            @"SELECT [Id], [Name], [AggregateId], [Version], [CreatedAt], [Payload], [Sequence] 
                 FROM [dbo].[EventStore] 
                 WHERE [AggregateId] = @AggregateId AND [Sequence] <= @Sequence
                 ORDER BY [Sequence]";

--- a/Tacta.EventStore/Tacta.EventStore.csproj
+++ b/Tacta.EventStore/Tacta.EventStore.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Dapper" Version="2.0.143" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Polly" Version="7.2.4" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />


### PR DESCRIPTION
- Removed saving full name of the types `$type` in the `payload` in Event Store.
- Added Converter between the Event type and it's name.
- Every Event needs to have a unique name in all scanned assemblies with Events.