### PR TITLE
Projections custom domain event

### DIFF
--- a/Tacta.EventStore.Test/Domain/AggregateRoots/BacklogItemCustomDomainEvent.cs
+++ b/Tacta.EventStore.Test/Domain/AggregateRoots/BacklogItemCustomDomainEvent.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using Tacta.EventStore.Domain;
+using Tacta.EventStore.Test.Domain.DomainEvents;
+using Tacta.EventStore.Test.Domain.Entities;
+using Tacta.EventStore.Test.Domain.Identities;
+
+namespace Tacta.EventStore.Test.Domain.AggregateRoots
+{
+    public class BacklogItemCustomDomainEvent : AggregateRoot<BacklogItemId>
+    {
+        public override BacklogItemId Id { get; protected set; }
+
+        public string Summary { get; private set; }
+
+        public List<SubTask> SubTasks { get; private set; } = new List<SubTask>();
+
+        private BacklogItemCustomDomainEvent() { }
+
+        public BacklogItemCustomDomainEvent(IReadOnlyCollection<IDomainEvent> events) : base(events)
+        {
+        }
+
+        public static BacklogItemCustomDomainEvent FromSummary(BacklogItemId id, string summary)
+        {
+            var item = new BacklogItemCustomDomainEvent();
+
+            item.Apply(new BacklogItemCreated(summary, id));
+
+            return item;
+        }
+
+        public void On(BacklogItemCreated @event)
+        {
+            Id = @event.BacklogItemId;
+            Summary = @event.Summary;
+        }
+    }
+}

--- a/Tacta.EventStore.Test/Domain/DomainEvents/BacklogItemCreatedCustomDomainEvent.cs
+++ b/Tacta.EventStore.Test/Domain/DomainEvents/BacklogItemCreatedCustomDomainEvent.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Newtonsoft.Json;
+using Tacta.EventStore.Test.Domain.Identities;
+
+namespace Tacta.EventStore.Test.Domain.DomainEvents
+{
+    public class BacklogItemCreatedCustomDomainEvent : CustomDomainEvent
+    {
+        public BacklogItemId BacklogItemId { get; }
+        public string Summary { get; }
+        
+        public BacklogItemCreatedCustomDomainEvent(string customDomainEventField, BacklogItemId backlogItemId, 
+            string summary) : base(customDomainEventField)
+        {
+            BacklogItemId = backlogItemId;
+            Summary = summary;
+        }
+
+        [JsonConstructor]
+        public BacklogItemCreatedCustomDomainEvent(
+            Guid id, 
+            DateTime createdAt,
+            string customDomainEventProperty,
+            BacklogItemId backlogItemId,
+            string summary
+            ) : base(id, createdAt, customDomainEventProperty)
+        {
+            BacklogItemId = backlogItemId;
+            Summary = summary;
+        }
+    }
+}

--- a/Tacta.EventStore.Test/Domain/DomainEvents/CustomDomainEvent.cs
+++ b/Tacta.EventStore.Test/Domain/DomainEvents/CustomDomainEvent.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Newtonsoft.Json;
+using Tacta.EventStore.Domain;
+
+namespace Tacta.EventStore.Test.Domain.DomainEvents
+{
+    public class CustomDomainEvent : IDomainEvent
+    {
+        public Guid Id { get; }
+        public long Sequence { get; private set; }
+        public int Version { get; private set; }
+        public DateTime CreatedAt { get; set; }
+        public string CustomDomainEventProperty { get; }
+
+        public CustomDomainEvent(string customDomainEventField)
+        {
+            Id = Guid.NewGuid();
+            CreatedAt = DateTime.Now;
+            Version = 0;
+            Sequence = 0;
+            CustomDomainEventProperty = customDomainEventField;
+        }
+
+        [JsonConstructor]
+        public CustomDomainEvent(Guid id, DateTime createdAt, string customDomainEventProperty)
+        {
+            (Id, CreatedAt, CustomDomainEventProperty) = (id, createdAt, customDomainEventProperty);
+        }
+
+        public void WithVersionAndSequence(int version, long sequence)
+        {
+            (Version, Sequence) = (version, sequence);
+        }
+    }
+}

--- a/Tacta.EventStore/Domain/DomainEvent.cs
+++ b/Tacta.EventStore/Domain/DomainEvent.cs
@@ -15,7 +15,6 @@ namespace Tacta.EventStore.Domain
 
         public DateTime CreatedAt { get; set; }
 
-       
         protected DomainEvent(string aggregateId)
         {
             (Id, AggregateId, CreatedAt, Version, Sequence) = (Guid.NewGuid(), aggregateId, DateTime.Now, 0, 0);
@@ -27,7 +26,7 @@ namespace Tacta.EventStore.Domain
             (Id, AggregateId, CreatedAt) = (id, aggregateId, createdAt);
         }
 
-        public void WithVersionAndSequence(int version, long sequence)
+        public virtual void WithVersionAndSequence(int version, long sequence)
         {
             (Version, Sequence) = (version, sequence);
         }

--- a/Tacta.EventStore/Domain/IDomainEvent.cs
+++ b/Tacta.EventStore/Domain/IDomainEvent.cs
@@ -11,5 +11,7 @@ namespace Tacta.EventStore.Domain
         int Version { get; }
         
         DateTime CreatedAt { get; set; }
+
+        void WithVersionAndSequence(int version, long sequence);
     }
 }

--- a/Tacta.EventStore/Projector/IProjectionProcessor.cs
+++ b/Tacta.EventStore/Projector/IProjectionProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Tacta.EventStore.Domain;
 
 namespace Tacta.EventStore.Projector
 {

--- a/Tacta.EventStore/Projector/ProjectionProcessor.cs
+++ b/Tacta.EventStore/Projector/ProjectionProcessor.cs
@@ -49,7 +49,7 @@ namespace Tacta.EventStore.Projector
             return content;
         }
 
-        public async Task<int> Process(int take = 100, bool processParallel = false)
+        public async Task<int> Process<T>(int take = 100, bool processParallel = false) where T : IDomainEvent
         {
             var processed = 0;
             
@@ -61,7 +61,7 @@ namespace Tacta.EventStore.Projector
                 await _processingSemaphore.WaitAsync().ConfigureAwait(false);
                 try
                 {
-                    var events = await Load(take).ConfigureAwait(false);
+                    var events = await Load<T>(take).ConfigureAwait(false);
                     
                     if (processParallel)
                     {
@@ -94,6 +94,15 @@ namespace Tacta.EventStore.Projector
             });
 
             return processed;
+        }
+
+        /// <summary>
+        /// Loads events from Event Store as <see cref="DomainEvent"/>
+        /// For custom domain events use <see cref="ProjectionProcessor.Process{T}(int, bool)"/>
+        /// </summary>
+        public async Task<int> Process(int take = 100, bool processParallel = false)
+        {
+            return await Process<DomainEvent>(take, processParallel);
         }
 
         public async Task Rebuild(IEnumerable<Type> projectionTypes = null)
@@ -138,14 +147,15 @@ namespace Tacta.EventStore.Projector
             _isInitialized = true;
         }
 
-        private async Task<IReadOnlyCollection<IDomainEvent>> Load(int take)
+        private async Task<IReadOnlyCollection<IDomainEvent>> Load<T>(int take) where T : IDomainEvent
         {
             var eventStoreRecords = await _eventStoreRepository
-                .GetFromSequenceAsync<DomainEvent>(_pivot, take).ConfigureAwait(false);
+                .GetFromSequenceAsync<T>(_pivot, take)
+                .ConfigureAwait(false);
 
             eventStoreRecords.ToList().ForEach(x => x.Event.WithVersionAndSequence(x.Version, x.Sequence));
 
-            return eventStoreRecords.Select(x => x.Event).ToList().AsReadOnly();
+            return eventStoreRecords.Select(x => (IDomainEvent)x.Event).ToList().AsReadOnly();
         }
     }
 }

--- a/Tacta.EventStore/Tacta.EventStore.csproj
+++ b/Tacta.EventStore/Tacta.EventStore.csproj
@@ -12,10 +12,10 @@
     <PackageIcon></PackageIcon>
     <PackageProjectUrl>https://tacta.io/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <Version>1.6.4</Version>
-    <PackageVersion>1.6.4</PackageVersion>
+    <Version>1.6.5</Version>
+    <PackageVersion>1.6.5</PackageVersion>
     <Title>Tacta EventStore Library</Title>
-    <PackageReleaseNotes>Saving multiple aggregates at once</PackageReleaseNotes>
+    <PackageReleaseNotes>Projections support custom domain event</PackageReleaseNotes>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>


### PR DESCRIPTION
If someone wanted to use a **custom domain event** which implements `IDomainEvent` interface he would not have the support for projections since projections explicitly used standard `DomainEvent` from the library. This feature adds support for custom domain events to be used in projections.