### PR TITLE
IDomainEvent rework

### DIFF
--- a/Tacta.EventStore.Test/Domain/AggregateRoots/BacklogItemCustomDomainEvent.cs
+++ b/Tacta.EventStore.Test/Domain/AggregateRoots/BacklogItemCustomDomainEvent.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using Tacta.EventStore.Domain;
+using Tacta.EventStore.Test.Domain.DomainEvents;
+using Tacta.EventStore.Test.Domain.Entities;
+using Tacta.EventStore.Test.Domain.Identities;
+
+namespace Tacta.EventStore.Test.Domain.AggregateRoots
+{
+    public class BacklogItemCustomDomainEvent : AggregateRoot<BacklogItemId>
+    {
+        public override BacklogItemId Id { get; protected set; }
+
+        public string Summary { get; private set; }
+
+        public List<SubTask> SubTasks { get; private set; } = new List<SubTask>();
+
+        private BacklogItemCustomDomainEvent() { }
+
+        public BacklogItemCustomDomainEvent(IReadOnlyCollection<IDomainEvent> events) : base(events)
+        {
+        }
+
+        public static BacklogItemCustomDomainEvent FromSummary(BacklogItemId id, string summary)
+        {
+            var item = new BacklogItemCustomDomainEvent();
+
+            item.Apply(new BacklogItemCreated(summary, id));
+
+            return item;
+        }
+
+        public void On(BacklogItemCreated @event)
+        {
+            Id = @event.BacklogItemId;
+            Summary = @event.Summary;
+        }
+    }
+}

--- a/Tacta.EventStore.Test/Domain/DomainEvents/BacklogItemCreatedCustomDomainEvent.cs
+++ b/Tacta.EventStore.Test/Domain/DomainEvents/BacklogItemCreatedCustomDomainEvent.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Newtonsoft.Json;
+using Tacta.EventStore.Test.Domain.Identities;
+
+namespace Tacta.EventStore.Test.Domain.DomainEvents
+{
+    public class BacklogItemCreatedCustomDomainEvent : CustomDomainEvent
+    {
+        public BacklogItemId BacklogItemId { get; }
+        public string Summary { get; }
+        
+        public BacklogItemCreatedCustomDomainEvent(string customDomainEventField, BacklogItemId backlogItemId, 
+            string summary) : base(customDomainEventField)
+        {
+            BacklogItemId = backlogItemId;
+            Summary = summary;
+        }
+
+        [JsonConstructor]
+        public BacklogItemCreatedCustomDomainEvent(
+            Guid id, 
+            DateTime createdAt,
+            string customDomainEventProperty,
+            BacklogItemId backlogItemId,
+            string summary
+            ) : base(id, createdAt, customDomainEventProperty)
+        {
+            BacklogItemId = backlogItemId;
+            Summary = summary;
+        }
+    }
+}

--- a/Tacta.EventStore.Test/Domain/DomainEvents/BacklogItemCreatedCustomDomainEvent.cs
+++ b/Tacta.EventStore.Test/Domain/DomainEvents/BacklogItemCreatedCustomDomainEvent.cs
@@ -20,10 +20,12 @@ namespace Tacta.EventStore.Test.Domain.DomainEvents
         public BacklogItemCreatedCustomDomainEvent(
             Guid id, 
             DateTime createdAt,
+            int version,
+            long sequence,
             string customDomainEventProperty,
             BacklogItemId backlogItemId,
             string summary
-            ) : base(id, createdAt, customDomainEventProperty)
+            ) : base(id, createdAt, customDomainEventProperty, version, sequence)
         {
             BacklogItemId = backlogItemId;
             Summary = summary;

--- a/Tacta.EventStore.Test/Domain/DomainEvents/CustomDomainEvent.cs
+++ b/Tacta.EventStore.Test/Domain/DomainEvents/CustomDomainEvent.cs
@@ -22,14 +22,9 @@ namespace Tacta.EventStore.Test.Domain.DomainEvents
         }
 
         [JsonConstructor]
-        public CustomDomainEvent(Guid id, DateTime createdAt, string customDomainEventProperty)
+        public CustomDomainEvent(Guid id, DateTime createdAt, string customDomainEventProperty, int version, long sequence)
         {
-            (Id, CreatedAt, CustomDomainEventProperty) = (id, createdAt, customDomainEventProperty);
-        }
-
-        public void WithVersionAndSequence(int version, long sequence)
-        {
-            (Version, Sequence) = (version, sequence);
+            (Id, CreatedAt, CustomDomainEventProperty, Version, Sequence) = (id, createdAt, customDomainEventProperty, version, sequence);
         }
     }
 }

--- a/Tacta.EventStore.Test/Domain/DomainEvents/CustomDomainEvent.cs
+++ b/Tacta.EventStore.Test/Domain/DomainEvents/CustomDomainEvent.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Newtonsoft.Json;
+using Tacta.EventStore.Domain;
+
+namespace Tacta.EventStore.Test.Domain.DomainEvents
+{
+    public class CustomDomainEvent : IDomainEvent
+    {
+        public Guid Id { get; }
+        public long Sequence { get; private set; }
+        public int Version { get; private set; }
+        public DateTime CreatedAt { get; set; }
+        public string CustomDomainEventProperty { get; }
+
+        public CustomDomainEvent(string customDomainEventField)
+        {
+            Id = Guid.NewGuid();
+            CreatedAt = DateTime.Now;
+            Version = 0;
+            Sequence = 0;
+            CustomDomainEventProperty = customDomainEventField;
+        }
+
+        [JsonConstructor]
+        public CustomDomainEvent(Guid id, DateTime createdAt, string customDomainEventProperty)
+        {
+            (Id, CreatedAt, CustomDomainEventProperty) = (id, createdAt, customDomainEventProperty);
+        }
+
+        public void WithVersionAndSequence(int version, long sequence)
+        {
+            (Version, Sequence) = (version, sequence);
+        }
+    }
+}

--- a/Tacta.EventStore.Test/Domain/DomainEvents/SubTaskAdded.cs
+++ b/Tacta.EventStore.Test/Domain/DomainEvents/SubTaskAdded.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Tacta.EventStore.Domain;
 using Tacta.EventStore.Test.Domain.Identities;

--- a/Tacta.EventStore.Test/Projector/DomainEvents/UserBanned.cs
+++ b/Tacta.EventStore.Test/Projector/DomainEvents/UserBanned.cs
@@ -4,6 +4,11 @@ namespace Tacta.EventStore.Test.Projector.DomainEvents
 {
     public sealed class UserBanned : DomainEvent
     {
-        public UserBanned(string aggregateId) : base(aggregateId) { }
+        public long Sequence { get; }
+
+        public UserBanned(string aggregateId, long sequence) : base(aggregateId)
+        {
+            Sequence = sequence;
+        }
     }
 }

--- a/Tacta.EventStore.Test/Projector/DomainEvents/UserRegistered.cs
+++ b/Tacta.EventStore.Test/Projector/DomainEvents/UserRegistered.cs
@@ -8,12 +8,13 @@ namespace Tacta.EventStore.Test.Projector.DomainEvents
     {
         public string Name { get; }
         public bool IsBanned { get; }
+        public long Sequence { get; }
 
-        public UserRegistered(string aggregateId, string name, bool isBanned)
-            : base(aggregateId) => (Name, IsBanned) = (name, isBanned);
+        public UserRegistered(string aggregateId, string name, bool isBanned, long sequence)
+            : base(aggregateId) => (Name, IsBanned, Sequence) = (name, isBanned, sequence);
 
         [JsonConstructor]
-        public UserRegistered(string aggregateId, Guid id, DateTime createdAt, string name, bool isBanned)
-            : base(id, aggregateId, createdAt) => (Name, IsBanned) = (name, isBanned);
+        public UserRegistered(string aggregateId, Guid id, DateTime createdAt, string name, bool isBanned, long sequence)
+            : base(id, aggregateId, createdAt) => (Name, IsBanned, Sequence) = (name, isBanned, sequence);
     }
 }

--- a/Tacta.EventStore.Test/Projector/DomainEvents/UserVerified.cs
+++ b/Tacta.EventStore.Test/Projector/DomainEvents/UserVerified.cs
@@ -4,6 +4,11 @@ namespace Tacta.EventStore.Test.Projector.DomainEvents
 {
     public sealed class UserVerified : DomainEvent
     {
-        public UserVerified(string aggregateId) : base(aggregateId) { }
+        public long Sequence { get; }
+
+        public UserVerified(string aggregateId, long sequence) : base(aggregateId)
+        {
+            Sequence = sequence;
+        }
     }
 }

--- a/Tacta.EventStore.Test/Projector/ProjectionTest.cs
+++ b/Tacta.EventStore.Test/Projector/ProjectionTest.cs
@@ -68,8 +68,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userRegistered.CreatedAt,
                         Event = userRegistered,
                         Id = Guid.NewGuid(),
-                        // Sequence = userRegistered.Sequence,
-                        // Version = userRegistered.Version
+                        Sequence = 120,
+                        Version = 0
                     }
                 });
 
@@ -165,8 +165,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userRegistered.CreatedAt,
                         Event = userRegistered,
                         Id = Guid.NewGuid(),
-                        // Sequence = userRegistered.Sequence,
-                        // Version = userRegistered.Version
+                        Sequence = 120,
+                        Version = 0
                     },
                     new EventStoreRecord<DomainEvent>
                     {
@@ -174,8 +174,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userBanned.CreatedAt,
                         Event = userBanned,
                         Id = Guid.NewGuid(),
-                        // Sequence = userBanned.Sequence,
-                        // Version = userBanned.Version
+                        Sequence = 345,
+                        Version = 1
                     }
                 });
 

--- a/Tacta.EventStore.Test/Projector/ProjectionTest.cs
+++ b/Tacta.EventStore.Test/Projector/ProjectionTest.cs
@@ -28,8 +28,7 @@ namespace Tacta.EventStore.Test.Projector
         public async Task OnUserRegistered()
         {
             // Given
-            var userRegistered = new UserRegistered("userId", "John Doe", false);
-            userRegistered.WithVersionAndSequence(1, 120);
+            var userRegistered = new UserRegistered("userId", "John Doe", false, 120);
 
             _eventStoreRepository.Setup(x => x.GetFromSequenceAsync<DomainEvent>(0, 100, CancellationToken.None))
                 .ReturnsAsync(new List<EventStoreRecord<DomainEvent>>
@@ -40,8 +39,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userRegistered.CreatedAt,
                         Event = userRegistered,
                         Id = Guid.NewGuid(),
-                        Sequence = userRegistered.Sequence,
-                        Version = userRegistered.Version
+                        Sequence = 120,
+                        Version = 1
                     }
                 });
 
@@ -58,8 +57,7 @@ namespace Tacta.EventStore.Test.Projector
         public async Task NoProjectionsAdded_ReturnsZero()
         {
             // Given
-            var userRegistered = new UserRegistered("userId", "John Doe", false);
-            userRegistered.WithVersionAndSequence(1, 120);
+            var userRegistered = new UserRegistered("userId", "John Doe", false, 120);
 
             _eventStoreRepository.Setup(x => x.GetFromSequenceAsync<DomainEvent>(0, 100, CancellationToken.None))
                 .ReturnsAsync(new List<EventStoreRecord<DomainEvent>>
@@ -70,8 +68,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userRegistered.CreatedAt,
                         Event = userRegistered,
                         Id = Guid.NewGuid(),
-                        Sequence = userRegistered.Sequence,
-                        Version = userRegistered.Version
+                        // Sequence = userRegistered.Sequence,
+                        // Version = userRegistered.Version
                     }
                 });
 
@@ -89,11 +87,9 @@ namespace Tacta.EventStore.Test.Projector
         public async Task OnUserBanned()
         {
             // Given
-            var userRegistered = new UserRegistered("userId", "John Doe", false);
-            userRegistered.WithVersionAndSequence(1, 120);
+            var userRegistered = new UserRegistered("userId", "John Doe", false, 120);
 
-            var userBanned = new UserBanned("userId");
-            userRegistered.WithVersionAndSequence(2, 345);
+            var userBanned = new UserBanned("userId", 345);
 
             _eventStoreRepository.Setup(x => x.GetFromSequenceAsync<DomainEvent>(0, 100, CancellationToken.None))
                 .ReturnsAsync(new List<EventStoreRecord<DomainEvent>>
@@ -104,8 +100,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userRegistered.CreatedAt,
                         Event = userRegistered,
                         Id = Guid.NewGuid(),
-                        Sequence = userRegistered.Sequence,
-                        Version = userRegistered.Version
+                        Sequence = 120,
+                        Version = 1
                     },
                     new EventStoreRecord<DomainEvent>
                     {
@@ -113,8 +109,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userBanned.CreatedAt,
                         Event = userBanned,
                         Id = Guid.NewGuid(),
-                        Sequence = userBanned.Sequence,
-                        Version = userBanned.Version
+                        Sequence = 345,
+                        Version = 2
                     }
                 });
 
@@ -156,11 +152,9 @@ namespace Tacta.EventStore.Test.Projector
         public async Task OnRebuildAndProcess()
         {
             // Given
-            var userRegistered = new UserRegistered("userId", "John Doe", false);
-            userRegistered.WithVersionAndSequence(1, 120);
+            var userRegistered = new UserRegistered("userId", "John Doe", false, 120);
 
-            var userBanned = new UserBanned("userId");
-            userRegistered.WithVersionAndSequence(2, 345);
+            var userBanned = new UserBanned("userId", 345);
 
             _eventStoreRepository.Setup(x => x.GetFromSequenceAsync<DomainEvent>(0, 100, CancellationToken.None))
                 .ReturnsAsync(new List<EventStoreRecord<DomainEvent>>
@@ -171,8 +165,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userRegistered.CreatedAt,
                         Event = userRegistered,
                         Id = Guid.NewGuid(),
-                        Sequence = userRegistered.Sequence,
-                        Version = userRegistered.Version
+                        // Sequence = userRegistered.Sequence,
+                        // Version = userRegistered.Version
                     },
                     new EventStoreRecord<DomainEvent>
                     {
@@ -180,8 +174,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userBanned.CreatedAt,
                         Event = userBanned,
                         Id = Guid.NewGuid(),
-                        Sequence = userBanned.Sequence,
-                        Version = userBanned.Version
+                        // Sequence = userBanned.Sequence,
+                        // Version = userBanned.Version
                     }
                 });
 
@@ -209,11 +203,9 @@ namespace Tacta.EventStore.Test.Projector
         public async Task OnNormalRebuildFlow()
         {
             // Given
-            var userRegistered = new UserRegistered("userId", "John Doe", false);
-            userRegistered.WithVersionAndSequence(1, 120);
+            var userRegistered = new UserRegistered("userId", "John Doe", false, 120);
 
-            var userBanned = new UserBanned("userId");
-            userRegistered.WithVersionAndSequence(2, 345);
+            var userBanned = new UserBanned("userId", 345);
 
             _eventStoreRepository.Setup(x => x.GetFromSequenceAsync<DomainEvent>(0, 100, CancellationToken.None))
                 .ReturnsAsync(new List<EventStoreRecord<DomainEvent>>
@@ -224,8 +216,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userRegistered.CreatedAt,
                         Event = userRegistered,
                         Id = Guid.NewGuid(),
-                        Sequence = userRegistered.Sequence,
-                        Version = userRegistered.Version
+                        Sequence = 120,
+                        Version = 1
                     },
                     new EventStoreRecord<DomainEvent>
                     {
@@ -233,8 +225,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userBanned.CreatedAt,
                         Event = userBanned,
                         Id = Guid.NewGuid(),
-                        Sequence = userBanned.Sequence,
-                        Version = userBanned.Version
+                        Sequence = 345,
+                        Version = 2
                     }
                 });
 

--- a/Tacta.EventStore.Test/Projector/ResilienceTest.cs
+++ b/Tacta.EventStore.Test/Projector/ResilienceTest.cs
@@ -108,14 +108,11 @@ namespace Tacta.EventStore.Test.Projector
         {
             _eventStoreRepository = new Mock<IEventStoreRepository>();
 
-            var userRegistered = new UserRegistered("User_123", "John Doe", false);
-            userRegistered.WithVersionAndSequence(1, 841);
+            var userRegistered = new UserRegistered("User_123", "John Doe", false, 841);
 
-            var userVerified = new UserVerified("User_123");
-            userVerified.WithVersionAndSequence(2, 842);
+            var userVerified = new UserVerified("User_123", 842);
 
-            var userBanned = new UserBanned("User_123");
-            userBanned.WithVersionAndSequence(3, 843);
+            var userBanned = new UserBanned("User_123", 843);
 
             _eventStoreRepository.Setup(x => x.GetFromSequenceAsync<DomainEvent>(0, 100, CancellationToken.None))
                 .ReturnsAsync(new List<EventStoreRecord<DomainEvent>>
@@ -126,8 +123,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userRegistered.CreatedAt,
                         Event = userRegistered,
                         Id = userRegistered.Id,
-                        Sequence = userRegistered.Sequence,
-                        Version = userRegistered.Version
+                        Sequence = 841,
+                        Version = 1
                     },
                     new EventStoreRecord<DomainEvent>
                     {
@@ -135,8 +132,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userVerified.CreatedAt,
                         Event = userVerified,
                         Id = userVerified.Id,
-                        Sequence = userVerified.Sequence,
-                        Version = userVerified.Version
+                        Sequence = 842,
+                        Version = 2
                     },
                     new EventStoreRecord<DomainEvent>
                     {
@@ -144,8 +141,8 @@ namespace Tacta.EventStore.Test.Projector
                         CreatedAt = userBanned.CreatedAt,
                         Event = userBanned,
                         Id = userBanned.Id,
-                        Sequence = userBanned.Sequence,
-                        Version = userBanned.Version
+                        Sequence = 843,
+                        Version = 3
                     }
                 });
         }

--- a/Tacta.EventStore.Test/Repository/EventStoreRepositoryTest.cs
+++ b/Tacta.EventStore.Test/Repository/EventStoreRepositoryTest.cs
@@ -23,7 +23,6 @@ namespace Tacta.EventStore.Test.Repository
             _eventStoreRepository = new EventStoreRepository(ConnectionFactory);
         }
 
-
         [Fact]
         public async Task InsertAsync_GetAsync_SingleAggregate()
         {
@@ -165,7 +164,7 @@ namespace Tacta.EventStore.Test.Repository
             var aggregate1 = new Aggregate(aggregateRecordBoo1, eventRecordsBoo1);
 
 
-            var aggregateRecordBoo2 = new AggregateRecord(booId2, "Boo", 1);
+            var aggregateRecordBoo2 = new AggregateRecord(booId2, "Boo", 0);
             var eventRecordsBoo2 = new List<EventRecord<IDomainEvent>>
             {
                 new EventRecord<IDomainEvent>(booCreated2.Id, booCreated2.CreatedAt, booCreated2)

--- a/Tacta.EventStore/Domain/DomainEvent.cs
+++ b/Tacta.EventStore/Domain/DomainEvent.cs
@@ -9,27 +9,18 @@ namespace Tacta.EventStore.Domain
 
         public string AggregateId { get; }
 
-        [JsonIgnore] public int Version { get; private set; }
-
-        [JsonIgnore] public long Sequence { get; private set; }
-
         public DateTime CreatedAt { get; set; }
 
        
         protected DomainEvent(string aggregateId)
         {
-            (Id, AggregateId, CreatedAt, Version, Sequence) = (Guid.NewGuid(), aggregateId, DateTime.Now, 0, 0);
+            (Id, AggregateId, CreatedAt) = (Guid.NewGuid(), aggregateId, DateTime.Now);
         }
 
         [JsonConstructor]
         protected DomainEvent(Guid id, string aggregateId, DateTime createdAt)
         {
             (Id, AggregateId, CreatedAt) = (id, aggregateId, createdAt);
-        }
-
-        public void WithVersionAndSequence(int version, long sequence)
-        {
-            (Version, Sequence) = (version, sequence);
         }
     }
 }

--- a/Tacta.EventStore/Domain/IDomainEvent.cs
+++ b/Tacta.EventStore/Domain/IDomainEvent.cs
@@ -11,5 +11,7 @@ namespace Tacta.EventStore.Domain
         int Version { get; }
         
         DateTime CreatedAt { get; set; }
+
+        void WithVersionAndSequence(int version, long sequence);
     }
 }

--- a/Tacta.EventStore/Domain/IDomainEvent.cs
+++ b/Tacta.EventStore/Domain/IDomainEvent.cs
@@ -6,12 +6,6 @@ namespace Tacta.EventStore.Domain
     {
         Guid Id { get; }
 
-        long Sequence { get; }
-
-        int Version { get; }
-        
         DateTime CreatedAt { get; set; }
-
-        void WithVersionAndSequence(int version, long sequence);
     }
 }

--- a/Tacta.EventStore/Projector/IProjection.cs
+++ b/Tacta.EventStore/Projector/IProjection.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Tacta.EventStore.Domain;
+using Tacta.EventStore.Repository;
 
 namespace Tacta.EventStore.Projector
 {
     public interface IProjection
     {
-        Task Apply(IReadOnlyCollection<IDomainEvent> events);
+        Task Apply<T>(IReadOnlyCollection<EventStoreRecord<T>> events);
 
         Task Initialize();
 

--- a/Tacta.EventStore/Projector/IProjectionProcessor.cs
+++ b/Tacta.EventStore/Projector/IProjectionProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Tacta.EventStore.Domain;
 
 namespace Tacta.EventStore.Projector
 {

--- a/Tacta.EventStore/Projector/Projection.cs
+++ b/Tacta.EventStore/Projector/Projection.cs
@@ -17,21 +17,19 @@ namespace Tacta.EventStore.Projector
             _projectionRepository = projectionRepository;
         }
 
-        public async Task Apply(IReadOnlyCollection<IDomainEvent> events)
+        public async Task Apply<T>(IReadOnlyCollection<EventStoreRecord<T>> records)
         {
-            foreach (var @event in events.OrderBy(x => x.Sequence))
+            foreach (var record in records.OrderBy(x => x.Sequence))
             {
-                if (@event.Sequence <= _sequence) continue;
+                if (record.Sequence <= _sequence) continue;
 
-                await ((dynamic)this).On((dynamic)@event);
+                await ((dynamic)this).On((dynamic)record.Event);
 
-                _sequence = @event.Sequence;
+                _sequence = record.Sequence;
             }
         }
 
         public async Task Initialize() => _sequence = await _projectionRepository.GetSequenceAsync().ConfigureAwait(false);
-
-        public async Task On(IDomainEvent @event) => await Task.FromResult(_sequence = @event.Sequence).ConfigureAwait(false);
 
         public long GetSequence() => _sequence;
         

--- a/Tacta.EventStore/Projector/ProjectionProcessor.cs
+++ b/Tacta.EventStore/Projector/ProjectionProcessor.cs
@@ -154,7 +154,6 @@ namespace Tacta.EventStore.Projector
                 .ConfigureAwait(false);
 
             return eventStoreRecords;
-            // return eventStoreRecords.Select(x => (IDomainEvent)x.Event).ToList().AsReadOnly();
         }
     }
 }

--- a/Tacta.EventStore/Projector/ProjectionProcessor.cs
+++ b/Tacta.EventStore/Projector/ProjectionProcessor.cs
@@ -49,7 +49,7 @@ namespace Tacta.EventStore.Projector
             return content;
         }
 
-        public async Task<int> Process(int take = 100, bool processParallel = false)
+        public async Task<int> Process<T>(int take = 100, bool processParallel = false) where T : IDomainEvent
         {
             var processed = 0;
             
@@ -61,7 +61,7 @@ namespace Tacta.EventStore.Projector
                 await _processingSemaphore.WaitAsync().ConfigureAwait(false);
                 try
                 {
-                    var events = await Load(take).ConfigureAwait(false);
+                    var events = await Load<T>(take).ConfigureAwait(false);
                     
                     if (processParallel)
                     {
@@ -94,6 +94,15 @@ namespace Tacta.EventStore.Projector
             });
 
             return processed;
+        }
+
+        /// <summary>
+        /// Loads events from Event Store as <see cref="DomainEvent"/>
+        /// For custom domain events use <see cref="ProjectionProcessor.Process{T}(int, bool)"/>
+        /// </summary>
+        public async Task<int> Process(int take = 100, bool processParallel = false)
+        {
+            return await Process<DomainEvent>(take, processParallel);
         }
 
         public async Task Rebuild(IEnumerable<Type> projectionTypes = null)
@@ -138,14 +147,15 @@ namespace Tacta.EventStore.Projector
             _isInitialized = true;
         }
 
-        private async Task<IReadOnlyCollection<IDomainEvent>> Load(int take)
+        private async Task<IReadOnlyCollection<IDomainEvent>> Load<T>(int take) where T : IDomainEvent
         {
             var eventStoreRecords = await _eventStoreRepository
-                .GetFromSequenceAsync<DomainEvent>(_pivot, take).ConfigureAwait(false);
+                .GetFromSequenceAsync<T>(_pivot, take)
+                .ConfigureAwait(false);
 
             eventStoreRecords.ToList().ForEach(x => x.Event.WithVersionAndSequence(x.Version, x.Sequence));
 
-            return eventStoreRecords.Select(x => x.Event).ToList().AsReadOnly();
+            return eventStoreRecords.Select(x => (IDomainEvent)x.Event).ToList().AsReadOnly();
         }
     }
 }


### PR DESCRIPTION
`IDomainEvent` and its implementations do not need the `Sequence` and `Version` properties along side them being filled in after instantiation of the implementing object. This feature's goal is to simplify `IDomainEvent` and reduce complexity in the library. Also by removing those properties it is easier to create custom domain events.